### PR TITLE
記事作成画面でカテゴリを選択できる機能を追加

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -3,7 +3,6 @@
 module Api
   module V1
     class ArticlesController < ApplicationController
-      # TODO: upload_thumbnailでなぜCookieが取れないのか
       skip_before_action :authenticate_user_from_token!, only: [:index, :show]
       skip_before_action :verify_authenticity_token, only: [:create, :update]
       before_action :upload_files, only: [:create]

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class CategoriesController < ApplicationController
+      skip_before_action :authenticate_user_from_token!, only: [:index]
+
+      def index
+        categories = Category.all
+        render status: 200, json: categories
+      end
+    end
+  end
+end

--- a/client/src/app/components/article/create-article/create-article.component.html
+++ b/client/src/app/components/article/create-article/create-article.component.html
@@ -33,7 +33,15 @@
               clearButtonCaption="CLEAR IMAGES"
               (uploadFinished)="onUploadFinished($event)">
             </image-upload>
-            <img [src]="uploadResult?.downloadURL || ''">
+            <div class='label-div'>
+              <img [src]="uploadResult?.downloadURL || ''">
+            </div>
+            <select class='category label-div'>
+              <option [ngValue]="null">カテゴリを選択</option>
+              <option *ngFor="let category of categories" [ngValue]="category.id">
+                {{category.name}}
+              </option>
+            </select>
       </div>
       <button class='create-btn fa' type="submit">
         <i class="fa fa-sign-in" aria-hidden="true"></i>投稿

--- a/client/src/app/components/article/create-article/create-article.component.scss
+++ b/client/src/app/components/article/create-article/create-article.component.scss
@@ -48,4 +48,8 @@
   .label-div {
     margin-bottom: 3%;
   }
+
+  .category {
+    width: 15%;
+  }
 }

--- a/client/src/app/components/article/create-article/create-article.component.ts
+++ b/client/src/app/components/article/create-article/create-article.component.ts
@@ -1,7 +1,9 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { FormGroup, FormControl } from '@angular/forms';
 import { ArticleService } from '../article.service';
+import { CategoryService } from 'src/app/shared/services/category-service.service';
 import { Article } from 'src/app/shared/models/article';
+import { Category } from 'src/app/shared/models/category';
 import { Router, ActivatedRoute } from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
 import { MarkdownService } from 'ngx-markdown';
@@ -19,8 +21,10 @@ export class CreateArticleComponent implements OnInit {
   articleId: number;
   uploadFileUuids = [];
   uploadFileEndpoint: string;
+  categories: Array<Category>;
 
   constructor(private articleService: ArticleService,
+              private categoryService: CategoryService,
               private router: Router,
               private cookieService: CookieService,
               private route: ActivatedRoute,
@@ -33,6 +37,7 @@ export class CreateArticleComponent implements OnInit {
     this.articleLoaded = false;
     this.articleId = this.route.snapshot.params['article_id'];
     this.loadArticle();
+    this.getCategories();
   }
 
   onSubmit() {
@@ -115,6 +120,16 @@ export class CreateArticleComponent implements OnInit {
 
   dataLoaded(): boolean {
     return this.articleLoaded;
+  }
+
+  getCategories() {
+    this.categoryService.getCategories().subscribe(
+      response => {
+        this.categories = response;
+      },
+      error => {
+      },
+    );
   }
 // tslint:disable-next-line:max-file-line-count
 }

--- a/client/src/app/shared/models/category.ts
+++ b/client/src/app/shared/models/category.ts
@@ -1,0 +1,4 @@
+export class Category {
+  id: number;
+  name: string;
+}

--- a/client/src/app/shared/services/category-service.service.spec.ts
+++ b/client/src/app/shared/services/category-service.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CategoryServiceService } from './category-service.service';
+
+describe('CategoryServiceService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: CategoryServiceService = TestBed.get(CategoryServiceService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/client/src/app/shared/services/category-service.service.ts
+++ b/client/src/app/shared/services/category-service.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs/Observable';
+import { environment } from '../../../environments/environment';
+import { Category } from '../models/category';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CategoryService {
+  apiEndpoint = environment.apiEndpoint;
+
+  constructor(private http: HttpClient) { }
+
+  getCategories(): Observable<Array<Category>> {
+    return this.http.get<Array<Category>>(`${this.apiEndpoint}/categories`);
+  }
+}

--- a/client/src/app/shared/services/upload-file.service.spec.ts
+++ b/client/src/app/shared/services/upload-file.service.spec.ts
@@ -1,12 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 
-import { UploadFilesService } from './upload-files.service';
+import { UploadFileService } from './upload-file.service';
 
-describe('UploadFilesService', () => {
+describe('UploadFileService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
   it('should be created', () => {
-    const service: UploadFilesService = TestBed.get(UploadFilesService);
+    const service: UploadFileService = TestBed.get(UploadFileService);
     expect(service).toBeTruthy();
   });
 });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
       resources :articles
       resources :upload_files, only: [:create]
       resources :thumbnails, only: [:create]
+      resources :categories, only: [:index]
     end
   end
 end


### PR DESCRIPTION
## 必要な理由
* 記事にカテゴリを紐付けたいため

## 対応内容
### フロントエンドの変更
* サーバからカテゴリを取得する処理を追加
* 記事作成画面でカテゴリを選択できるように変更

### サーバサイドの変更
* カテゴリ取得APIを作成

## その他（確認したいことがあれば）
* カテゴリ取得APIの追加と記事作成画面でカテゴリを選択できるようにしただけで、紐づける処理はまだ

