### PR TITLE
記事作成時にカテゴリを紐づける様に変更

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -47,7 +47,7 @@ module Api
 
       private
       def article_params
-        params[:article].permit(:title, :mark_content, :html_content)
+        params[:article].permit(:title, :mark_content, :html_content, :category_id)
       end
 
       def move_to_index

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :html_content, :mark_content, :user_id, :created_at, :updated_at, :thumbnail_url, :category
+  attributes :id, :title, :html_content, :mark_content, :user_id, :created_at, :updated_at,
+             :thumbnail_url, :category, :category_id
 
   def thumbnail_url
     return nil unless object.thumbnail

--- a/client/src/app/components/article/create-article/create-article.component.html
+++ b/client/src/app/components/article/create-article/create-article.component.html
@@ -36,7 +36,7 @@
             <div class='label-div'>
               <img [src]="uploadResult?.downloadURL || ''">
             </div>
-            <select class='category label-div'>
+            <select class='category label-div' formControlName="category_id">
               <option [ngValue]="null">カテゴリを選択</option>
               <option *ngFor="let category of categories" [ngValue]="category.id">
                 {{category.name}}

--- a/client/src/app/components/article/create-article/create-article.component.ts
+++ b/client/src/app/components/article/create-article/create-article.component.ts
@@ -98,6 +98,7 @@ export class CreateArticleComponent implements OnInit {
       this.form = new FormGroup({
         title: new FormControl(),
         mark_content: new FormControl(),
+        category_id: new FormControl(),
       });
       this.articleLoaded = true;
     }
@@ -109,6 +110,7 @@ export class CreateArticleComponent implements OnInit {
         this.form = new FormGroup({
           title: new FormControl(response.title),
           mark_content: new FormControl(response.mark_content),
+          category_id: new FormControl(response.category_id),
         });
         this.articleLoaded = true;
       },

--- a/client/src/app/shared/models/article.ts
+++ b/client/src/app/shared/models/article.ts
@@ -9,4 +9,5 @@ export class Article {
   upload_file_uuids: any[];
   thumbnail_url: string;
   category: string;
+  category_id: integer;
 }


### PR DESCRIPTION
## 必要な理由
* 記事にカテゴリを紐付け、絞り込み等に使用するため

## 対応内容
### フロントエンドの変更
* 記事作成時にカテゴリーのidをサーバに送る様に変更

### サーバサイドの変更
* createメソッドにカテゴリーを紐づける処理を追加
* 編集時に使用するのでarticleのresponseにcategory_idを追加

## その他（確認したいことがあれば）
* 

