### PR TITLE
記事に公開/非公開のステータスを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,4 +14,14 @@ class User < ApplicationRecord
     self.access_token = "#{self.id}:#{Devise.friendly_token}"
     save
   end
+
+  class << self
+    def logged_in?(cookies)
+      auth_token = cookies[:access_token]
+      return false unless auth_token
+      user_id = auth_token.split(':').first
+      user = User.where(id: user_id).first
+      return user && Devise.secure_compare(user.access_token, auth_token)
+    end
+  end
 end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -2,7 +2,7 @@
 
 class ArticleSerializer < ActiveModel::Serializer
   attributes :id, :title, :html_content, :mark_content, :user_id, :created_at, :updated_at,
-             :category, :category_id
+             :published, :category, :category_id
   attribute :thumbnail_url, if: :include_thumbnail?
   attribute :comments, if: :include_comments?
 

--- a/client/src/app/components/article/article.component.html
+++ b/client/src/app/components/article/article.component.html
@@ -4,6 +4,11 @@
     <div>
       <div *ngIf="loginState" class='article-element'>
         <button class='click-util edit-btn' routerLink="/article/{{article.id}}/edit">編集</button>
+        <div>
+          <button class='click-util publish-btn' (click)="changePublishStatus(article.id)">
+            {{article.published ? '非公開にする' : '公開する' }}
+          </button>
+        </div>
       </div>
       <div class='article-element'>
         <span>投稿日時: {{article.created_at | date:"yyyy/MM/dd HH:mm"}}</span>

--- a/client/src/app/components/article/article.component.scss
+++ b/client/src/app/components/article/article.component.scss
@@ -47,3 +47,19 @@
   background-color: #0044cc;
   border: solid 1px #0044cc;
 }
+
+.publish-btn {
+  color: #fff;
+  border-color: #d24d4d;
+  background-color: #d24d4d;
+  border-radius: 4px;
+  font-weight: 700;
+  width: 10rem;
+  height: 4rem;
+  margin-bottom: 2%;
+}
+
+.publish-btn:hover {
+  background-color: red;
+  border: solid 1px red;
+}

--- a/client/src/app/components/article/article.component.ts
+++ b/client/src/app/components/article/article.component.ts
@@ -4,6 +4,7 @@ import { Article } from '@models/article';
 import { Router, ActivatedRoute } from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
 import { AuthService } from '@services/auth.service';
+import { ConfirmDialogService } from '@services/confirm-dialog.service';
 
 @Component({
   selector: 'app-article',
@@ -20,7 +21,8 @@ export class ArticleComponent implements OnInit {
               private router: Router,
               private route: ActivatedRoute,
               private cookieService: CookieService,
-              private authService: AuthService) { }
+              private authService: AuthService,
+              private confirmDialogService: ConfirmDialogService) { }
 
   ngOnInit() {
     this.articleLoaded = false;
@@ -67,5 +69,26 @@ export class ArticleComponent implements OnInit {
         },
       );
     }
+  }
+
+  changePublishStatus(articleId: number) {
+    const dialogTitle = this.article.published ? '非公開' : '公開';
+    this.confirmDialogService.showConfirm({
+      title: '公開状況変更',
+      content: `${dialogTitle}に変更しますか？'`,
+      acceptButton: '変更する',
+      cancelButton: 'キャンセル',
+      isDanger: true,
+    }).subscribe(confirm => {
+      if (confirm) {
+        this.articleService.changePublishStatus(articleId).subscribe(
+          response => {
+            this.article = response;
+          },
+          error => {
+          },
+        );
+      }
+    });
   }
 }

--- a/client/src/app/components/comment/comment.component.ts
+++ b/client/src/app/components/comment/comment.component.ts
@@ -63,7 +63,7 @@ export class CommentComponent implements OnInit {
         },
         error => {
           this.commonForm();
-        }
+        },
       );
     } else {
       this.commonForm();
@@ -149,4 +149,5 @@ export class CommentComponent implements OnInit {
       }
     });
   }
+// tslint:disable-next-line:max-file-line-count
 }

--- a/client/src/app/shared/models/article.ts
+++ b/client/src/app/shared/models/article.ts
@@ -13,4 +13,5 @@ export class Article {
   category: string;
   category_id: number;
   comments: Array<Comment>;
+  published: boolean;
 }

--- a/client/src/app/shared/services/article.service.ts
+++ b/client/src/app/shared/services/article.service.ts
@@ -33,6 +33,10 @@ export class ArticleService {
     return this.http.get<Array<Article>>(`${this.apiEndpoint}/articles/search`, { params: params }  );
   }
 
+  changePublishStatus(articleId: number): Observable<Article> {
+    return this.http.post<Article>(`${this.apiEndpoint}/articles/update_publish_status`, { id: articleId }  );
+  }
+
   async loadLatestArticles() {
     const articles = await this.getLatesAticles();
     return articles.map(item => Object.assign(new Article, item));

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
         collection do
           get :search
           get :create_months
+          post :update_publish_status
         end
       end
       resources :upload_files, only: [:create]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "category_id"
+    t.boolean "published", default: false, null: false
   end
 
   create_table "blog_informations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|

--- a/db/schemas/articles.schema
+++ b/db/schemas/articles.schema
@@ -6,4 +6,5 @@ create_table "articles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSE
   t.datetime "created_at", null: false
   t.datetime "updated_at", null: false
   t.integer "category_id"
+  t.boolean "published", null: false, default: 0
 end


### PR DESCRIPTION
## 必要な理由
* 投稿後、公開する前に確認するため

## 対応内容
### フロントエンドの変更
* 公開状況変更ボタンを追加

### サーバサイドの変更
* articleにpublishedのステータスを追加
* 記事の公開状況を変更するAPIを追加

## その他（確認したいことがあれば）
* 

