### PR TITLE
フロントのコードのbuildパスを変更

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -4,8 +4,8 @@ var replace = require('gulp-replace');
 var now = Date.now();
 
 gulp.task('add-querystring-to-index', function () {
-  return gulp.src(['/home/webapp/public/index.html'])
+  return gulp.src(['../public/index.html'])
     .pipe(replace('.css', '.css?t=' + now))
     .pipe(replace('.js', '.js?t=' + now))
-    .pipe(gulp.dest('/home/webapp/public/'));
+    .pipe(gulp.dest('../public/'));
 });

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "start": "ng serve --disable-host-check",
     "build": "ng build",
-    "build-prod": "ng build --prod --output-path=/home/webapp/public && gulp add-querystring-to-index",
+    "build-prod": "ng build --prod --output-path=../public && gulp add-querystring-to-index",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"


### PR DESCRIPTION
## 必要な理由
* デプロイ時に直接nginxの参照ディレクトリを更新すると、一時的にサイトが使えなくなるため

## 対応内容
### フロントエンドの変更
* 

### サーバサイドの変更
* 

## その他（確認したいことがあれば）
* 

