### PR TITLE
タブレット用にレウアウトを修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -9,10 +9,10 @@ module Api
 
       def index
         limit = params[:limit] || 5
-        @articles = Article.joins(:comments, :thumbnail)
-                           .where(published: published_option)
+        articl_id = Article.order('created_at desc').limit(limit).ids
+        @articles = Article.eager_load(:comments, :thumbnail)
+                           .where(published: published_option, id: articl_id)
                            .order('articles.created_at desc, comments.created_at asc')
-                           .limit(limit)
         include_option = params[:limit] == '1' ? true : false
         render status: 200, json: @articles, each_serializer: ArticleSerializer,
           include_comments: include_option, include_thumbnail: !include_option

--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -14,11 +14,17 @@
   @include respond-to(smartphonen) {
     width: 100%;
   }
+  @include respond-to(tablet) {
+    width: 35%;
+  }
 }
 
 .app-layout {
   width: 78%;
   @include respond-to(smartphone) {
     width: 100%;
+  }
+  @include respond-to(tablet) {
+    width: 65%;
   }
 }

--- a/client/src/app/components/comment/comment.component.scss
+++ b/client/src/app/components/comment/comment.component.scss
@@ -95,4 +95,7 @@ h3 {
   @include respond-to(smartphone) {
     width: 90%;
   }
+  @include respond-to(tablet) {
+    width: 90%;
+  }
 }

--- a/client/src/app/components/contact/contact.component.scss
+++ b/client/src/app/components/contact/contact.component.scss
@@ -75,6 +75,9 @@ h2 {
 
 .content {
   @include respond-to(smartphone) {
-    width: 100%;
+    width: 90%;
+  }
+  @include respond-to(tablet) {
+    width: 90%;
   }
 }

--- a/client/src/assets/styles/mixins.scss
+++ b/client/src/assets/styles/mixins.scss
@@ -1,5 +1,6 @@
 $breakpoints: (
-  smartphone: '(max-width: 480px)',
+  smartphone: '(max-width: 700px)',
+  tablet: '(max-width: 1150px)',
 );
 
 @mixin respond-to($breakpoint) {


### PR DESCRIPTION
## 必要な理由
* タブレットで画面が崩れるため

## 対応内容
### フロントエンドの変更
* タブレットの大きさを指定し、それ以下の場合はレイアウトを修正する
* スマートフォンの大きさ指定を修正

### サーバサイドの変更
* 記事取得APIにバグがあったのでついでに修正

## その他（確認したいことがあれば）
* 

