### PR TITLE
universalを実現するための準備

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,6 @@
     "core-js": "^2.5.4",
     "font-awesome": "^4.7.0",
     "ng2-adsense": "^5.4.1",
-    "ngx-cookie-service": "^2.0.0",
     "ngx-markdown": "^7.1.3",
     "rxjs": "~6.3.3",
     "rxjs-compat": "^6.3.3",

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -8,7 +8,7 @@ import { AngularMarkdownEditorModule } from 'angular-markdown-editor';
 import { MarkdownModule } from 'ngx-markdown';
 import { AdsenseModule } from 'ng2-adsense';
 
-import { HttpsInterceptor } from '@services/http.interceptor';
+import { HttpsInterceptor } from './shared/services/http.interceptor';
 
 import { AppComponent } from './app.component';
 import { ArticleComponent } from './components/article/article.component';
@@ -31,7 +31,7 @@ import { SearchArticleComponent } from './components/article/search-article/sear
 import { ContactComponent } from './components/contact/contact.component';
 import { CommentComponent } from './components/comment/comment.component';
 
-import { ConfirmDialogService } from '@services/confirm-dialog.service';
+import { ConfirmDialogService } from './shared/services/confirm-dialog.service';
 import { ConfirmDialogComponent } from './components/confirm-dialog/confirm-dialog.component';
 
 @NgModule({

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -3,7 +3,6 @@ import { NgModule } from '@angular/core';
 import { AppRoutingModule } from './app-routing.module';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
-import { CookieService } from 'ngx-cookie-service';
 import { ImageUploadModule } from 'angular2-image-upload';
 import { AngularMarkdownEditorModule } from 'angular-markdown-editor';
 import { MarkdownModule } from 'ngx-markdown';
@@ -73,7 +72,6 @@ import { ConfirmDialogComponent } from './components/confirm-dialog/confirm-dial
     }),
   ],
   providers: [
-    CookieService,
     { provide: HTTP_INTERCEPTORS, useClass: HttpsInterceptor, multi: true },
     ConfirmDialogService,
   ],

--- a/client/src/app/components/account/login/login.component.ts
+++ b/client/src/app/components/account/login/login.component.ts
@@ -3,7 +3,6 @@ import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { ValidateForm } from '@functions/validate-forms';
 import { SessionService } from '../session.service';
 import { User } from '@models/user';
-import { CookieService } from 'ngx-cookie-service';
 import { Router } from '@angular/router';
 
 @Component({
@@ -29,7 +28,6 @@ export class LoginComponent implements OnInit {
   };
 
   constructor(private sessionService: SessionService,
-              private cookieService: CookieService,
               private router: Router) { }
 
   ngOnInit() {
@@ -46,9 +44,7 @@ export class LoginComponent implements OnInit {
       this.user = this.form.value;
 
       this.sessionService.login(this.user).subscribe(
-        data => {
-          this.cookieService.set( 'login_email', data['email'], 1 );
-          this.cookieService.set( 'access_token', data['access_token'], 1 );
+        response => {
           location.href = '/';
         },
         error => {

--- a/client/src/app/components/account/login/login.component.ts
+++ b/client/src/app/components/account/login/login.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
-import { ValidateForm } from '@functions/validate-forms';
+import { ValidateForm } from '../../../shared/functions/validate-forms';
 import { SessionService } from '../session.service';
-import { User } from '@models/user';
+import { User } from '../../../shared//models/user';
 import { Router } from '@angular/router';
 
 @Component({

--- a/client/src/app/components/account/session.service.ts
+++ b/client/src/app/components/account/session.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
-import { User } from '@models/user';
-import { environment } from '@environments/environment';
+import { User } from '../../shared/models/user';
+import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root',

--- a/client/src/app/components/article/article.component.ts
+++ b/client/src/app/components/article/article.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit } from '@angular/core';
-import { ArticleService } from '@services/article.service';
-import { Article } from '@models/article';
+import { ArticleService } from '../../shared/services/article.service';
+import { Article } from '../../shared/models/article';
 import { ActivatedRoute } from '@angular/router';
-import { AuthService } from '@services/auth.service';
-import { ConfirmDialogService } from '@services/confirm-dialog.service';
+import { AuthService } from '../../shared/services/auth.service';
+import { ConfirmDialogService } from '../../shared/services//confirm-dialog.service';
 import { Meta } from '@angular/platform-browser';
 
 @Component({

--- a/client/src/app/components/article/article.component.ts
+++ b/client/src/app/components/article/article.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ArticleService } from '@services/article.service';
 import { Article } from '@models/article';
-import { Router, ActivatedRoute } from '@angular/router';
-import { CookieService } from 'ngx-cookie-service';
+import { ActivatedRoute } from '@angular/router';
 import { AuthService } from '@services/auth.service';
 import { ConfirmDialogService } from '@services/confirm-dialog.service';
 import { Meta } from '@angular/platform-browser';
@@ -18,9 +17,7 @@ export class ArticleComponent implements OnInit {
   loginState: boolean;
 
   constructor(private articleService: ArticleService,
-              private router: Router,
               private route: ActivatedRoute,
-              private cookieService: CookieService,
               private authService: AuthService,
               private confirmDialogService: ConfirmDialogService,
               private metaService: Meta) { }
@@ -61,16 +58,13 @@ export class ArticleComponent implements OnInit {
   }
 
   getLoginState() {
-    const loginEmail = this.cookieService.get('login_email');
-    if (!!loginEmail) {
-      this.loginState = this.authService.loginState().then(
-        response => {
-          this.loginState = response['login_state'];
-        },
-        error => {
-        },
-      );
-    }
+    this.authService.loginState().then(
+      response => {
+        this.loginState = response['login_state'];
+      },
+      error => {
+      },
+    );
   }
 
   changePublishStatus(articleId: number) {

--- a/client/src/app/components/article/create-article/create-article.component.ts
+++ b/client/src/app/components/article/create-article/create-article.component.ts
@@ -1,14 +1,14 @@
 import { Component, OnInit } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
-import { ValidateForm } from '@functions/validate-forms';
-import { ArticleService } from '@services/article.service';
-import { CategoryService } from '@services/category.service';
-import { Article } from '@models/article';
-import { Category } from '@models/category';
+import { ValidateForm } from '../../../shared/functions/validate-forms';
+import { ArticleService } from '../../../shared/services//article.service';
+import { CategoryService } from '../../../shared/services/category.service';
+import { Article } from '../../../shared/models/article';
+import { Category } from '../../../shared/models/category';
 import { Router, ActivatedRoute } from '@angular/router';
 import { MarkdownService } from 'ngx-markdown';
-import { environment } from '@environments/environment';
-import { AuthService } from '@services/auth.service';
+import { environment } from '../../../../environments/environment';
+import { AuthService } from '../../../shared/services/auth.service';
 
 @Component({
   selector: 'app-create-article',

--- a/client/src/app/components/article/create-article/create-article.component.ts
+++ b/client/src/app/components/article/create-article/create-article.component.ts
@@ -6,9 +6,9 @@ import { CategoryService } from '@services/category.service';
 import { Article } from '@models/article';
 import { Category } from '@models/category';
 import { Router, ActivatedRoute } from '@angular/router';
-import { CookieService } from 'ngx-cookie-service';
 import { MarkdownService } from 'ngx-markdown';
 import { environment } from '@environments/environment';
+import { AuthService } from '@services/auth.service';
 
 @Component({
   selector: 'app-create-article',
@@ -42,15 +42,15 @@ export class CreateArticleComponent implements OnInit {
   constructor(private articleService: ArticleService,
               private categoryService: CategoryService,
               private router: Router,
-              private cookieService: CookieService,
               private route: ActivatedRoute,
               private markdownService: MarkdownService,
+              private authService: AuthService,
             ) { }
 
   ngOnInit() {
     this.categoryLoaded = false;
     this.uploadFileEndpoint = environment.uploadFileEndpoint;
-    this.loginCheck();
+    this.getLoginState();
     this.articleLoaded = false;
     this.articleId = this.route.snapshot.params['article_id'];
     this.loadArticle();
@@ -108,13 +108,6 @@ export class CreateArticleComponent implements OnInit {
     );
   }
 
-  // TODO: serviceに置き換える
-  loginCheck() {
-    if (!!!this.cookieService.get('login_email')) {
-      this.router.navigateByUrl(`/`);
-    }
-  }
-
   loadArticle() {
     if (this.articleId) {
       this.getArticle(this.articleId);
@@ -150,6 +143,18 @@ export class CreateArticleComponent implements OnInit {
         this.categoryLoaded = true;
       }
     });
+  }
+
+  getLoginState() {
+    this.authService.loginState().then(
+      response => {
+        if ( response['login_state'] === false ) {
+          this.router.navigateByUrl(`/`);
+        }
+      },
+      error => {
+      },
+    );
   }
 // tslint:disable-next-line:max-file-line-count
 }

--- a/client/src/app/components/article/latest-article/latest-article.component.ts
+++ b/client/src/app/components/article/latest-article/latest-article.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { ArticleService } from '@services/article.service';
-import { Article } from '@models/article';
+import { ArticleService } from '../../../shared/services/article.service';
+import { Article } from '../../../shared/models/article';
 import { Observable } from 'rxjs';
 import 'rxjs/add/observable/interval';
 

--- a/client/src/app/components/article/search-article/search-article.component.ts
+++ b/client/src/app/components/article/search-article/search-article.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { ArticleService } from '@services/article.service';
-import { Article } from '@models/article';
-import { Category } from '@models/category';
-import { CategoryService } from '@services/category.service';
+import { ArticleService } from '../../../shared/services/article.service';
+import { Article } from '../../../shared/models/article';
+import { Category } from '../../../shared/models/category';
+import { CategoryService } from '../../../shared/services/category.service';
 
 @Component({
   selector: 'app-search-article',

--- a/client/src/app/components/comment/comment.component.ts
+++ b/client/src/app/components/comment/comment.component.ts
@@ -1,10 +1,10 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { FormGroup, FormControl, Validators, PatternValidator } from '@angular/forms';
-import { ValidateForm } from '@functions/validate-forms';
-import { Comment } from '@models/comment';
-import { CommentService } from '@services/comment.service';
-import { AuthService } from '@services/auth.service';
-import { ConfirmDialogService } from '@services/confirm-dialog.service';
+import { ValidateForm } from '../../shared/functions/validate-forms';
+import { Comment } from '../../shared/models/comment';
+import { CommentService } from '../../shared/services/comment.service';
+import { AuthService } from '../../shared/services/auth.service';
+import { ConfirmDialogService } from '../../shared/services/confirm-dialog.service';
 
 @Component({
   selector: 'app-comment',

--- a/client/src/app/components/comment/comment.component.ts
+++ b/client/src/app/components/comment/comment.component.ts
@@ -4,8 +4,6 @@ import { ValidateForm } from '@functions/validate-forms';
 import { Comment } from '@models/comment';
 import { CommentService } from '@services/comment.service';
 import { AuthService } from '@services/auth.service';
-import { Router } from '@angular/router';
-import { CookieService } from 'ngx-cookie-service';
 import { ConfirmDialogService } from '@services/confirm-dialog.service';
 
 @Component({
@@ -39,35 +37,29 @@ export class CommentComponent implements OnInit {
 
   constructor(private commentService: CommentService,
               private authService: AuthService,
-              private router: Router,
-              private cookieService: CookieService,
               private confirmDialogService: ConfirmDialogService) { }
 
   ngOnInit() {
     this.isDisabled = false;
+    this.loginState = false;
     this.readyCommentForm = false;
     this.initializeForm();
   }
 
   initializeForm() {
-    const loginEmail = this.cookieService.get('login_email');
-    if (!!loginEmail) {
-      this.loginState = this.authService.loginState().then(
-        response => {
-          this.loginState = response['login_state'];
-          if (this.loginState) {
-            this.ownerForm();
-          } else {
-            this.commonForm();
-          }
-        },
-        error => {
+    this.authService.loginState().then(
+      response => {
+        this.loginState = response['login_state'];
+        if (this.loginState) {
+          this.ownerForm();
+        } else {
           this.commonForm();
-        },
-      );
-    } else {
-      this.commonForm();
-    }
+        }
+      },
+      error => {
+        this.commonForm();
+      },
+    );
   }
 
   commonForm() {
@@ -118,7 +110,7 @@ export class CommentComponent implements OnInit {
   }
 
   getLoginState() {
-    this.loginState = this.authService.loginState().then(
+    this.authService.loginState().then(
       response => {
         this.loginState = response['login_state'];
       },

--- a/client/src/app/components/confirm-dialog/confirm-dialog.component.ts
+++ b/client/src/app/components/confirm-dialog/confirm-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ConfirmDialogService } from '@services/confirm-dialog.service';
+import { ConfirmDialogService } from '../../shared/services/confirm-dialog.service';
 
 @Component({
   selector: 'app-confirm-dialog',

--- a/client/src/app/components/contact/contact.component.ts
+++ b/client/src/app/components/contact/contact.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
-import { ValidateForm } from '@functions/validate-forms';
-import { Contact } from '@models/contact';
-import { ContactService } from '@services/contact.service';
+import { ValidateForm } from '../../shared/functions/validate-forms';
+import { Contact } from '../../shared/models/contact';
+import { ContactService } from '../../shared/services/contact.service';
 
 @Component({
   selector: 'app-contact',

--- a/client/src/app/components/header/header.component.ts
+++ b/client/src/app/components/header/header.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { BlogInformation } from '@models/blog-information';
-import { BlogInformationService } from '@services/blog-information.service';
+import { BlogInformation } from '../../shared/models/blog-information';
+import { BlogInformationService } from '../../shared/services/blog-information.service';
 
 @Component({
   selector: 'app-header',

--- a/client/src/app/components/menu/menu.component.ts
+++ b/client/src/app/components/menu/menu.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { AuthService } from '@services/auth.service';
+import { AuthService } from '../../shared/services/auth.service';
 
 @Component({
   selector: 'app-menu',

--- a/client/src/app/components/menu/menu.component.ts
+++ b/client/src/app/components/menu/menu.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { CookieService } from 'ngx-cookie-service';
 import { AuthService } from '@services/auth.service';
 
 @Component({
@@ -10,23 +9,20 @@ import { AuthService } from '@services/auth.service';
 export class MenuComponent implements OnInit {
   loginState: boolean;
 
-  constructor(private authService: AuthService,
-              private cookieService: CookieService) { }
+  constructor(private authService: AuthService) { }
 
   ngOnInit() {
+    this.loginState = false;
     this.getLoginState();
   }
 
   getLoginState() {
-    const loginEmail = this.cookieService.get('login_email');
-    if (!!loginEmail) {
-      this.loginState = this.authService.loginState().then(
-        response => {
-          this.loginState = response['login_state'];
-        },
-        error => {
-        },
-      );
-    }
+    this.authService.loginState().then(
+      response => {
+        this.loginState = response['login_state'];
+      },
+      error => {
+      },
+    );
   }
 }

--- a/client/src/app/components/profile/profile.component.ts
+++ b/client/src/app/components/profile/profile.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { BlogInformation } from '@models/blog-information';
-import { BlogInformationService} from '@services/blog-information.service';
+import { BlogInformation } from '../../shared/models/blog-information';
+import { BlogInformationService} from '../../shared/services/blog-information.service';
 
 @Component({
   selector: 'app-profile',

--- a/client/src/app/components/sidebar/advertisement/advertisement.component.ts
+++ b/client/src/app/components/sidebar/advertisement/advertisement.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { Advertisement } from '@models/advertisement';
-import { AdvertisementService } from '@services/advertisement.service';
+import { Advertisement } from '../../../shared/models/advertisement';
+import { AdvertisementService } from '../../../shared/services/advertisement.service';
 
 @Component({
   selector: 'app-advertisement',

--- a/client/src/app/components/sidebar/search-category/search-category.component.ts
+++ b/client/src/app/components/sidebar/search-category/search-category.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { Category } from '@models/category';
-import { CategoryService } from '@services/category.service';
+import { Category } from '../../../shared/models/category';
+import { CategoryService } from '../../../shared/services/category.service';
 import { Router } from '@angular/router';
 
 @Component({

--- a/client/src/app/components/sidebar/search-text/search-text.component.ts
+++ b/client/src/app/components/sidebar/search-text/search-text.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
-import { ValidateForm } from '@functions/validate-forms';
+import { ValidateForm } from '../../../shared/functions/validate-forms';
 import { Router } from '@angular/router';
 
 @Component({

--- a/client/src/app/shared/models/article.ts
+++ b/client/src/app/shared/models/article.ts
@@ -1,4 +1,4 @@
-import { Comment } from '@models/comment';
+import { Comment } from '../models/comment';
 
 export class Article {
   id: number;

--- a/client/src/app/shared/services/advertisement.service.ts
+++ b/client/src/app/shared/services/advertisement.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
-import { environment } from '@environments/environment';
+import { environment } from '../../../environments/environment';
 import { Advertisement } from '../models/advertisement';
 
 @Injectable({

--- a/client/src/app/shared/services/article.service.ts
+++ b/client/src/app/shared/services/article.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
-import { Article } from '@models/article';
-import { environment } from '@environments/environment';
+import { Article } from '../models/article';
+import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root',

--- a/client/src/app/shared/services/auth.service.ts
+++ b/client/src/app/shared/services/auth.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
-import { CookieService } from 'ngx-cookie-service';
+import { HttpClient } from '@angular/common/http';
 import { environment } from '@environments/environment';
 
 @Injectable({
@@ -9,11 +8,9 @@ import { environment } from '@environments/environment';
 export class AuthService {
   apiEndpoint = environment.apiEndpoint;
 
-  constructor(private http: HttpClient,
-              private cookieService: CookieService) { }
+  constructor(private http: HttpClient) { }
 
   loginState(): any {
-    const params = new HttpParams().set('login_email', this.cookieService.get('login_email'));
-    return this.http.get(`${this.apiEndpoint}/login_state`, { params: params } ).toPromise();
+    return this.http.get(`${this.apiEndpoint}/login_state`).toPromise();
   }
 }

--- a/client/src/app/shared/services/auth.service.ts
+++ b/client/src/app/shared/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { environment } from '@environments/environment';
+import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root',

--- a/client/src/app/shared/services/blog-information.service.ts
+++ b/client/src/app/shared/services/blog-information.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
-import { environment } from '@environments/environment';
+import { environment } from '../../../environments/environment';
 import { BlogInformation } from '../models/blog-information';
 
 @Injectable({

--- a/client/src/app/shared/services/category.service.ts
+++ b/client/src/app/shared/services/category.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs/Observable';
-import { environment } from '@environments/environment';
+import { environment } from '../../../environments/environment';
 import { Category } from '../models/category';
 
 @Injectable({

--- a/client/src/app/shared/services/comment.service.ts
+++ b/client/src/app/shared/services/comment.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
-import { Comment } from '@models/comment';
-import { environment } from '@environments/environment';
+import { Comment } from '../models/comment';
+import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root',

--- a/client/src/app/shared/services/contact.service.ts
+++ b/client/src/app/shared/services/contact.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs/Observable';
-import { environment } from '@environments/environment';
+import { environment } from '../../../environments/environment';
 import { Contact } from '../models/contact';
 
 @Injectable({

--- a/client/src/app/shared/services/http.interceptor.ts
+++ b/client/src/app/shared/services/http.interceptor.ts
@@ -1,11 +1,10 @@
 import { Injectable } from '@angular/core';
 import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
-import { CookieService } from 'ngx-cookie-service';
 
 @Injectable()
 export class HttpsInterceptor implements HttpInterceptor {
-  constructor(private cookieService: CookieService) {}
+  constructor() {}
   // リクエストの変換処理。ここに共通処理を記述。
   intercept(
     request: HttpRequest<any>,
@@ -14,7 +13,6 @@ export class HttpsInterceptor implements HttpInterceptor {
       request = request.clone({
         setHeaders: {
           'Content-Type': 'application/json',
-          'Authorization': this.cookieService.get('access_token'),
         },
         withCredentials: true,
       });

--- a/client/src/app/shared/services/thumbnail.service.ts
+++ b/client/src/app/shared/services/thumbnail.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { environment } from '@environments/environment';
+import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root',

--- a/client/src/app/shared/services/upload-file.service.ts
+++ b/client/src/app/shared/services/upload-file.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { environment } from '@environments/environment';
+import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root',

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -2,13 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "baseUrl": "src",
-    "paths": {
-      "@components/*": ["app/components/*"],
-      "@services/*": ["app/shared/services/*"],
-      "@models/*": ["app/shared/models/*"],
-      "@environments/*": ["environments/*"],
-      "@functions/*": ["app/shared/functions/*"],
-    },
+    "paths": {},
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4492,10 +4492,6 @@ ng2-adsense@^5.4.1:
   dependencies:
     tslib "^1.9.0"
 
-ngx-cookie-service@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ngx-cookie-service/-/ngx-cookie-service-2.0.0.tgz#ef1cd3d97d9ffc354de6113b08d29d879d257533"
-
 ngx-markdown@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/ngx-markdown/-/ngx-markdown-7.1.3.tgz#e3d5498987e5464da782ae0d1b699dfe77213e35"


### PR DESCRIPTION
## 必要な理由
* SSR化するため

## 対応内容
### フロントエンドの変更
* ngx-cookie-serviseはuniversalに対応していないので、使わないように変更（フロント側でcookieを使わない）
* includePathを利用したpathの省略をやめる

### サーバサイドの変更
* サーバ側でcookieを保存するように対応

## その他（確認したいことがあれば）
* 

