### PR TITLE
月別アーカイブの機能を追加

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -63,8 +63,8 @@ module Api
       end
 
       def monthly_archive
-        archive = Article.where(published: true).monthly_archive
-        render status: 200, json: archive
+        archives = Article.where(published: true).monthly_archive
+        render status: 200, json: monthly_archive_response(archives)
       end
 
       def update_publish_status
@@ -113,6 +113,15 @@ module Api
 
       def search_parms_valid?
         params[:category_id].present? || params[:keyword].present?
+      end
+
+      def monthly_archive_response(archives)
+        years = []
+        archives.keys.each do |key|
+          years << key[0..3]
+        end
+        years.uniq!
+        { years: years, archives: archives }
       end
     end
   end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -53,11 +53,7 @@ module Api
       def search
         render_invalid_request && return unless search_parms_valid?
 
-        if params[:category_id]
-          @articles = Article.with_thumbnail(published_option).by_category(params[:category_id])
-        else
-          @articles = Article.with_thumbnail(published_option).by_keyword(params[:keyword])
-        end
+        @articles = searched_articles
         render status: 200, json: @articles, each_serializer: ArticleSerializer,
           include_thumbnail: true
       end
@@ -113,7 +109,17 @@ module Api
       end
 
       def search_parms_valid?
-        params[:category_id].present? || params[:keyword].present?
+        params[:category_id].present? || params[:keyword].present? || params[:date].present?
+      end
+
+      def searched_articles
+        if params[:date]
+          Article.with_thumbnail(published_option).by_date(params[:date])
+        elsif params[:category_id]
+          Article.with_thumbnail(published_option).by_category(params[:category_id])
+        else
+          Article.with_thumbnail(published_option).by_keyword(params[:keyword])
+        end
       end
     end
   end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class ArticlesController < ApplicationController
       skip_before_action :authenticate_user_from_token!,
-        only: [:index, :show, :search, :create_months]
+        only: [:index, :show, :search, :create_months, :monthly_archive]
 
       def index
         limit = params[:limit] || 5
@@ -62,10 +62,9 @@ module Api
           include_thumbnail: true
       end
 
-      # TODO: 現状使っていない
-      def create_months
-        create_months = Article.select(:created_at).map{ |i| i.created_at.strftime('%Y年%m月') }.uniq
-        render status: 200, json: create_months
+      def monthly_archive
+        archive = Article.where(published: true).monthly_archive
+        render status: 200, json: archive
       end
 
       def update_publish_status

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class ArticlesController < ApplicationController
       skip_before_action :authenticate_user_from_token!,
-        only: [:index, :show, :search, :create_months, :monthly_archive]
+        only: [:index, :show, :search, :monthly_archive]
 
       def index
         limit = params[:limit] || 5

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class ArticlesController < ApplicationController
       skip_before_action :authenticate_user_from_token!,
-        only: [:index, :show, :search, :monthly_archive]
+        only: [:index, :show, :search, :archive]
 
       def index
         limit = params[:limit] || 5
@@ -62,9 +62,10 @@ module Api
           include_thumbnail: true
       end
 
-      def monthly_archive
+      def archive
         archives = Article.where(published: true).monthly_archive
-        render status: 200, json: monthly_archive_response(archives)
+        archive_response_service = Articles::ArchiveResponseService.new(archives)
+        render status: 200, json: archive_response_service.call
       end
 
       def update_publish_status
@@ -113,15 +114,6 @@ module Api
 
       def search_parms_valid?
         params[:category_id].present? || params[:keyword].present?
-      end
-
-      def monthly_archive_response(archives)
-        years = []
-        archives.keys.each do |key|
-          years << key[0..3]
-        end
-        years.uniq!
-        { years: years, archives: archives }
       end
     end
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -24,6 +24,10 @@ class Article < ApplicationRecord
   scope :with_thumbnail, -> (published_option) do
     includes(:thumbnail).where(published: published_option).order('articles.created_at desc')
   end
+  scope :by_date, -> (date) do
+    formated_date = Date.strptime(date, '%Y/%m')
+    where("DATE_FORMAT(created_at, '%Y%m') = DATE_FORMAT('#{formated_date }', '%Y%m')")
+  end
 
   class << self
     def latest_ids(published_option, limit)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -31,8 +31,8 @@ class Article < ApplicationRecord
     end
 
     def monthly_archive
-      self.group("DATE_FORMAT(created_at, '%Y%m')")
-          .order("DATE_FORMAT(created_at, '%Y%m') desc").count
+      self.group("DATE_FORMAT(created_at, '%Y/%m')")
+          .order("DATE_FORMAT(created_at, '%Y/%m') desc").count
     end
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -29,5 +29,10 @@ class Article < ApplicationRecord
     def latest_ids(published_option, limit)
       self.where(published: published_option).order('created_at desc').limit(limit).ids
     end
+
+    def monthly_archive
+      self.group("DATE_FORMAT(created_at, '%Y%m')")
+          .order("DATE_FORMAT(created_at, '%Y%m') desc").count
+    end
   end
 end

--- a/app/services/articles/archive_response_service.rb
+++ b/app/services/articles/archive_response_service.rb
@@ -13,20 +13,25 @@ module Articles
     def call
       initialize_response
       create_response
-      @response
+      response = []
+      @response.each { |res| response << res[1] }
+      response
     end
 
     def initialize_response
       @years.each do |year|
-        @response[year.to_sym] = { count: 0, monthly_archives: {} }
+        @response[year] = { year: year, count: 0, monthly_archives: [] }
       end
     end
 
     def create_response
       @archives.each do |archive|
-        key = archive[0][0..3].to_sym
-        @response[key][:count] = @response[key][:count] + archive[1]
-        @response[key][:monthly_archives][archive[0].to_sym] = archive[1]
+        # NOTE: @archives = { '2019/04' => 1, '2019/05' => 3 }
+        #       archive[0] = '2019/04'
+        #       archive[1] = 1
+        year = archive[0][0..3]
+        @response[year][:count] = @response[year][:count] + archive[1]
+        @response[year][:monthly_archives] << { month: archive[0], count: archive[1]}
       end
     end
   end

--- a/app/services/articles/archive_response_service.rb
+++ b/app/services/articles/archive_response_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Articles
+  class ArchiveResponseService
+    def initialize(archives)
+      @archives = archives
+      @years = []
+      archives.keys.each { |key| @years << key[0..3] }
+      @years.uniq!
+      @response = {}
+    end
+
+    def call
+      initialize_response
+      create_response
+      @response
+    end
+
+    def initialize_response
+      @years.each do |year|
+        @response[year.to_sym] = { count: 0, monthly_archives: {} }
+      end
+    end
+
+    def create_response
+      @archives.each do |archive|
+        key = archive[0][0..3].to_sym
+        @response[key][:count] = @response[key][:count] + archive[1]
+        @response[key][:monthly_archives][archive[0].to_sym] = archive[1]
+      end
+    end
+  end
+end

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { ImageUploadModule } from 'angular2-image-upload';
 import { AngularMarkdownEditorModule } from 'angular-markdown-editor';
 import { MarkdownModule } from 'ngx-markdown';
 import { AdsenseModule } from 'ng2-adsense';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { HttpsInterceptor } from './shared/services/http.interceptor';
 
@@ -33,6 +34,7 @@ import { CommentComponent } from './components/comment/comment.component';
 
 import { ConfirmDialogService } from './shared/services/confirm-dialog.service';
 import { ConfirmDialogComponent } from './components/confirm-dialog/confirm-dialog.component';
+import { MonthlyArchiveComponent } from './components/sidebar/monthly-archive/monthly-archive.component';
 
 @NgModule({
   declarations: [
@@ -57,6 +59,7 @@ import { ConfirmDialogComponent } from './components/confirm-dialog/confirm-dial
     ContactComponent,
     CommentComponent,
     ConfirmDialogComponent,
+    MonthlyArchiveComponent,
   ],
   imports: [
     BrowserModule.withServerTransition({ appId: 'serverApp' }),
@@ -70,6 +73,7 @@ import { ConfirmDialogComponent } from './components/confirm-dialog/confirm-dial
     AdsenseModule.forRoot({
       adClient: 'ca-pub-4015300938527195',
     }),
+    BrowserAnimationsModule,
   ],
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: HttpsInterceptor, multi: true },

--- a/client/src/app/components/article/article.component.html
+++ b/client/src/app/components/article/article.component.html
@@ -11,7 +11,7 @@
         </div>
       </div>
       <div class='article-element'>
-        <span>投稿日時: {{article.created_at | date:"yyyy/MM/dd HH:mm"}}</span>
+        <span>投稿日時: {{article.created_at | date:"yyyy/MM/dd HH:mm" : '+0000'}}</span>
       </div>
       <div class='article-element category' *ngIf="article.category">
         <span>{{article.category}}</span>

--- a/client/src/app/components/article/search-article/search-article.component.html
+++ b/client/src/app/components/article/search-article/search-article.component.html
@@ -11,7 +11,7 @@
           <td>
             <p>{{article.category}}</p>
             <p>{{article.title}}</p>
-            <p class='date'>{{article.created_at | date:'yyyy/MM/dd HH:mm'}}</p>
+            <p class='date'>{{article.created_at | date:'yyyy/MM/dd HH:mm' : '+0000'}}</p>
           </td>
         </tr>
       </div>

--- a/client/src/app/components/article/search-article/search-article.component.scss
+++ b/client/src/app/components/article/search-article/search-article.component.scss
@@ -32,6 +32,9 @@ img{
   @include respond-to(smartphone) {
     width: 27rem;
   }
+  @include respond-to(tablet) {
+    width: 40rem;
+  }
 }
 
 .click-util:hover {

--- a/client/src/app/components/comment/comment.component.html
+++ b/client/src/app/components/comment/comment.component.html
@@ -4,7 +4,7 @@
     <div>
       <div class='commented-div' *ngFor="let comment of comments">
         <span class='commented-name'>{{comment.name}}</span>
-        <span class='comented-date'>{{comment.created_at | date:"yyyy/MM/dd HH:mm"}}</span>
+        <span class='comented-date'>{{comment.created_at | date:"yyyy/MM/dd HH:mm" : '+0000'}}</span>
         <p class='commented-content'>
           {{comment.content}}
           <button *ngIf="loginState" (click)="deleteComment(comment.id)" class='click-util delete-btn'>削除</button>

--- a/client/src/app/components/comment/comment.component.scss
+++ b/client/src/app/components/comment/comment.component.scss
@@ -62,6 +62,7 @@ h3 {
   padding: 10px;
   width: 90%;
   white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .commented-name {

--- a/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.html
+++ b/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.html
@@ -1,12 +1,12 @@
 <div class='monthly-archive'>
   <h4>月別アーカイブ</h4>
   <div class='dates'>
-    <div class="year click-util" (click)="onAccordion(archive[0])" *ngFor="let archive of archives">
+    <div class="year click-util" (click)="onAccordion(archive['year'])" *ngFor="let archive of archives">
       <i [ngClass]="showDetail ? 'fa fa-minus-circle' : 'fa fa-plus-circle'"></i>
-      &nbsp;{{ archive[0] }}（{{ archive[1]['count'] }}）
-      <ng-container *ngIf="showDetail == archive[0]">
-        <div class='months' [@accordion] *ngFor="let month of getMonths(archive[1]['monthly_archives'])">
-          <p>{{month[0]}}（{{month[1]}}）</p>
+      &nbsp;{{ archive['year'] }}（{{ archive['count'] }}）
+      <ng-container *ngIf="showDetail == archive['year']">
+        <div class='months' [@accordion] *ngFor="let month of archive['monthly_archives']">
+          <p>{{month['month']}}（{{month['count']}}）</p>
         </div>
       </ng-container>
     </div>

--- a/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.html
+++ b/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.html
@@ -1,12 +1,16 @@
 <div class='monthly-archive'>
   <h4>月別アーカイブ</h4>
   <div class='dates'>
-    <div class="year click-util" (click)="onAccordion(archive['year'])" *ngFor="let archive of archives">
-      <i [ngClass]="showDetail ? 'fa fa-minus-circle' : 'fa fa-plus-circle'"></i>
-      &nbsp;{{ archive['year'] }}（{{ archive['count'] }}）
+    <div class="year" *ngFor="let archive of archives">
+      <p class='click-util' (click)="onAccordion(archive['year'])">
+        <i [ngClass]="showDetail ? 'fa fa-minus-circle' : 'fa fa-plus-circle'"></i>
+        &nbsp;{{ archive['year'] }}（{{ archive['count'] }}）
+      </p>
       <ng-container *ngIf="showDetail == archive['year']">
         <div class='months' [@accordion] *ngFor="let month of archive['monthly_archives']">
-          <p>{{month['month']}}（{{month['count']}}）</p>
+          <p class='click-util' [routerLink]="['/search']" [queryParams]="{ date: month['month'] }">
+            {{month['month']}}（{{month['count']}}）
+          </p>
         </div>
       </ng-container>
     </div>

--- a/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.html
+++ b/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.html
@@ -8,7 +8,7 @@
       </p>
       <ng-container *ngIf="showDetail == archive['year']">
         <div class='months' [@accordion] *ngFor="let month of archive['monthly_archives']">
-          <p class='click-util' [routerLink]="['/search']" [queryParams]="{ date: month['month'] }">
+          <p class='click-util' [routerLink]="['/search']" [queryParams]="{ date: month['month'] }" fragment="top">
             {{month['month']}}（{{month['count']}}）
           </p>
         </div>

--- a/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.html
+++ b/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.html
@@ -1,24 +1,14 @@
 <div class='monthly-archive'>
   <h4>月別アーカイブ</h4>
   <div class='dates'>
-    <div class="year click-util" (click)="onAccordion()">
+    <div class="year click-util" (click)="onAccordion(archive[0])" *ngFor="let archive of archives">
       <i [ngClass]="showDetail ? 'fa fa-minus-circle' : 'fa fa-plus-circle'"></i>
-      &nbsp;2019
-    </div>
-    <!-- アコーディオンの中身 -->
-    <div class='months' *ngIf="showDetail" [@accordion]>
-      <p class='click-util'>2019/01</p>
-      <p class='click-util'>2019/02</p>
-      <p class='click-util'>2019/03</p>
-      <p class='click-util'>2019/04</p>
-      <p class='click-util'>2019/05</p>
-      <p class='click-util'>2019/06</p>
-      <p class='click-util'>2019/07</p>
-      <p class='click-util'>2019/08</p>
-      <p class='click-util'>2019/09</p>
-      <p class='click-util'>2019/10</p>
-      <p class='click-util'>2019/11</p>
-      <p class='click-util'>2019/12</p>
+      &nbsp;{{ archive[0] }}（{{ archive[1]['count'] }}）
+      <ng-container *ngIf="showDetail == archive[0]">
+        <div class='months' [@accordion] *ngFor="let month of getMonths(archive[1]['monthly_archives'])">
+          <p>{{month[0]}}（{{month[1]}}）</p>
+        </div>
+      </ng-container>
     </div>
   </div>
 </div>

--- a/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.html
+++ b/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.html
@@ -1,0 +1,24 @@
+<div class='monthly-archive'>
+  <h4>月別アーカイブ</h4>
+  <div class='dates'>
+    <div class="year click-util" (click)="onAccordion()">
+      <i [ngClass]="showDetail ? 'fa fa-minus-circle' : 'fa fa-plus-circle'"></i>
+      &nbsp;2019
+    </div>
+    <!-- アコーディオンの中身 -->
+    <div class='months' *ngIf="showDetail" [@accordion]>
+      <p class='click-util'>2019/01</p>
+      <p class='click-util'>2019/02</p>
+      <p class='click-util'>2019/03</p>
+      <p class='click-util'>2019/04</p>
+      <p class='click-util'>2019/05</p>
+      <p class='click-util'>2019/06</p>
+      <p class='click-util'>2019/07</p>
+      <p class='click-util'>2019/08</p>
+      <p class='click-util'>2019/09</p>
+      <p class='click-util'>2019/10</p>
+      <p class='click-util'>2019/11</p>
+      <p class='click-util'>2019/12</p>
+    </div>
+  </div>
+</div>

--- a/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.scss
+++ b/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.scss
@@ -14,7 +14,7 @@ h4 {
 }
 
 .dates {
-  margin-left: 5%;
+  margin-left: 10%;
 }
 
 .months {

--- a/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.scss
+++ b/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.scss
@@ -1,0 +1,27 @@
+@import "../../../../assets/styles/mixins";
+
+.monthly-archive {
+  margin-top: 15%;
+  width: 80%;
+  @include respond-to(smartphone) {
+    width: 100%;
+  }
+}
+
+h4 {
+  border-bottom: solid 1px;
+  margin-bottom: 3rem;
+}
+
+.dates {
+  margin-left: 5%;
+}
+
+.months {
+  margin-top: 2%;
+  margin-left: 12%;
+}
+
+.click-util:hover {
+  color: #0088c7;
+}

--- a/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.spec.ts
+++ b/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MonthlyArchiveComponent } from './monthly-archive.component';
+
+describe('MonthlyArchiveComponent', () => {
+  let component: MonthlyArchiveComponent;
+  let fixture: ComponentFixture<MonthlyArchiveComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MonthlyArchiveComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MonthlyArchiveComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.ts
+++ b/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.ts
@@ -1,0 +1,32 @@
+import { Component, OnInit } from '@angular/core';
+import { trigger, style, animate, transition } from '@angular/animations';
+
+@Component({
+  selector: 'app-monthly-archive',
+  templateUrl: './monthly-archive.component.html',
+  styleUrls: ['./monthly-archive.component.scss'],
+  animations: [
+    trigger('accordion', [
+      transition(':enter', [
+        style({ height: '0', opacity: 0, overflow: 'hidden' }),
+        animate('500ms', style({ height: '*', opacity: 1 })),
+      ]),
+      transition(':leave', [
+        style({ height: '*', opacity: '1', overflow: 'hidden' }),
+        animate('500ms', style({ height: '0' })),
+      ]),
+    ]),
+  ],
+})
+export class MonthlyArchiveComponent implements OnInit {
+  showDetail: boolean;
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+  onAccordion() {
+    this.showDetail = !this.showDetail;
+  }
+}

--- a/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.ts
+++ b/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.ts
@@ -29,7 +29,7 @@ export class MonthlyArchiveComponent implements OnInit {
   ngOnInit() {
     this.articleService.getArchives().subscribe(
       response => {
-        this.archives = Object.entries(response);
+        this.archives = response;
       },
     );
   }
@@ -40,9 +40,5 @@ export class MonthlyArchiveComponent implements OnInit {
     } else {
       this.showDetail = year;
     }
-  }
-
-  getMonths(year) {
-    return Object.entries(year);
   }
 }

--- a/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.ts
+++ b/client/src/app/components/sidebar/monthly-archive/monthly-archive.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { trigger, style, animate, transition } from '@angular/animations';
+import { ArticleService } from '../../../shared/services/article.service';
 
 @Component({
   selector: 'app-monthly-archive',
@@ -9,24 +10,39 @@ import { trigger, style, animate, transition } from '@angular/animations';
     trigger('accordion', [
       transition(':enter', [
         style({ height: '0', opacity: 0, overflow: 'hidden' }),
-        animate('500ms', style({ height: '*', opacity: 1 })),
+        animate('200ms', style({ height: '*', opacity: 1 })),
       ]),
       transition(':leave', [
         style({ height: '*', opacity: '1', overflow: 'hidden' }),
-        animate('500ms', style({ height: '0' })),
+        animate('200ms', style({ height: '0' })),
       ]),
     ]),
   ],
 })
 export class MonthlyArchiveComponent implements OnInit {
   showDetail: boolean;
+  years: Array<string>;
+  archives: any;
 
-  constructor() { }
+  constructor(private articleService: ArticleService) { }
 
   ngOnInit() {
+    this.articleService.getArchives().subscribe(
+      response => {
+        this.archives = Object.entries(response);
+      },
+    );
   }
 
-  onAccordion() {
-    this.showDetail = !this.showDetail;
+  onAccordion(year) {
+    if ( this.showDetail === year ) {
+      this.showDetail = null;
+    } else {
+      this.showDetail = year;
+    }
+  }
+
+  getMonths(year) {
+    return Object.entries(year);
   }
 }

--- a/client/src/app/components/sidebar/sidebar.component.html
+++ b/client/src/app/components/sidebar/sidebar.component.html
@@ -1,5 +1,6 @@
 <div class='sidebar'>
   <app-search-text></app-search-text>
   <app-search-category></app-search-category>
+  <app-monthly-archive></app-monthly-archive>
   <app-advertisement></app-advertisement>
 </div>

--- a/client/src/app/shared/services/article.service.ts
+++ b/client/src/app/shared/services/article.service.ts
@@ -37,6 +37,10 @@ export class ArticleService {
     return this.http.post<Article>(`${this.apiEndpoint}/articles/update_publish_status`, { id: articleId }  );
   }
 
+  getArchives(): Observable<any> {
+    return this.http.get<any>(`${this.apiEndpoint}/articles/archive`);
+  }
+
   async loadLatestArticles() {
     const articles = await this.getLatesAticles();
     return articles.map(item => Object.assign(new Article, item));

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
       resources :articles do
         collection do
           get :search
-          get :monthly_archive
+          get :archive
           post :update_publish_status
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
       resources :articles do
         collection do
           get :search
-          get :create_months
+          get :monthly_archive
           post :update_publish_status
         end
       end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -267,6 +267,18 @@ RSpec.describe Api::V1::ArticlesController, type: :request do
       end
     end
 
+    context '日付での検索' do
+      let(:params) { { date: article.created_at.strftime('%Y/%m') } }
+      before do
+        get '/api/v1/articles/search', params: params
+      end
+      it '検索に成功する' do
+        expect(response.code).to eq '200'
+        search_response = JSON.parse(response.body)
+        expect(search_response[0]['id']).to eq article.id
+      end
+    end
+
     context 'カテゴリでの検索' do
       let(:params) { { category_id: category.id } }
       before do

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -334,9 +334,9 @@ RSpec.describe Api::V1::ArticlesController, type: :request do
       end
       it '月別アーカイブのhashが返る' do
         expect(response.code).to eq '200'
-        article_date = article.created_at.strftime('%Y%m')
-        expected_response = {}
-        expected_response[article_date] = 1
+        article_year = article.created_at.strftime('%Y')
+        article_month = article.created_at.strftime('%Y/%m')
+        expected_response = { 'years' => [article_year], 'archives' => { article_month => 1 } }
         expect(JSON.parse(response.body)).to eq expected_response
       end
     end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -315,8 +315,32 @@ RSpec.describe Api::V1::ArticlesController, type: :request do
       end
     end
   end
-  # TODO: 使っていないAPIなので変更・削除する際にテストも編集する
-  # describe 'GET /api/v1/articles/create_months' do
+
+  describe 'GET /api/v1/articles/monthly_archive' do
+    context '記事がない場合' do
+      before do
+        Article.destroy_all
+        get '/api/v1/articles/monthly_archive'
+      end
+      it '空のhashが返る' do
+        expect(response.code).to eq '200'
+        expect(JSON.parse(response.body)).to be {}
+      end
+    end
+
+    context '記事がある場合' do
+      before do
+        get '/api/v1/articles/monthly_archive'
+      end
+      it '月別アーカイブのhashが返る' do
+        expect(response.code).to eq '200'
+        article_date = article.created_at.strftime('%Y%m')
+        expected_response = {}
+        expected_response[article_date] = 1
+        expect(JSON.parse(response.body)).to eq expected_response
+      end
+    end
+  end
 
   describe 'POST /api/v1/articles/update_publish_status' do
     let(:params) { { id: article.id } }

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -336,14 +336,18 @@ RSpec.describe Api::V1::ArticlesController, type: :request do
         expect(response.code).to eq '200'
         article_year = article.created_at.strftime('%Y')
         article_month = article.created_at.strftime('%Y/%m')
-        expected_response = {
-          article_year => {
+        expected_response = [
+          {
+            'year' => article_year,
             'count' => 1,
-            'monthly_archives' => {
-              article_month => 1
-            }
+            'monthly_archives' => [
+              {
+                'month' => article_month,
+                'count' => 1,
+              }
+            ]
           }
-        }
+        ]
         expect(JSON.parse(response.body)).to eq expected_response
       end
     end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -316,11 +316,11 @@ RSpec.describe Api::V1::ArticlesController, type: :request do
     end
   end
 
-  describe 'GET /api/v1/articles/monthly_archive' do
+  describe 'GET /api/v1/articles/archive' do
     context '記事がない場合' do
       before do
         Article.destroy_all
-        get '/api/v1/articles/monthly_archive'
+        get '/api/v1/articles/archive'
       end
       it '空のhashが返る' do
         expect(response.code).to eq '200'
@@ -330,13 +330,20 @@ RSpec.describe Api::V1::ArticlesController, type: :request do
 
     context '記事がある場合' do
       before do
-        get '/api/v1/articles/monthly_archive'
+        get '/api/v1/articles/archive'
       end
       it '月別アーカイブのhashが返る' do
         expect(response.code).to eq '200'
         article_year = article.created_at.strftime('%Y')
         article_month = article.created_at.strftime('%Y/%m')
-        expected_response = { 'years' => [article_year], 'archives' => { article_month => 1 } }
+        expected_response = {
+          article_year => {
+            'count' => 1,
+            'monthly_archives' => {
+              article_month => 1
+            }
+          }
+        }
         expect(JSON.parse(response.body)).to eq expected_response
       end
     end


### PR DESCRIPTION
## 必要な理由
* 過去の記事を探せるように

## 対応内容
### フロントエンドの変更
* 月別アーカイブ用のcomponentを追加
* DatePipeを使っている部分が日本時刻になっていなかったので全て日本時刻になるよう修正
* コメントが長い場合範囲からはみ出していたのでスタイルを修正

### サーバサイドの変更
* 月別アーカイブのAPIを作成
* 月で絞り込むAPIを作成

## その他（確認したいことがあれば）
* 

