### PR TITLE
公開済みの記事のみ次の記事、前の記事に表示するように修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -74,7 +74,8 @@ module Api
         after_status = article.published ? false : true
         article.published = after_status
         article.save!
-        render status: 200, json: article, serializer: ArticleSerializer, include_comments: true
+        render status: 200, json: article,
+          serializer: ArticleSerializer, include_comments: true, include_next: true
       end
 
       private

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -52,10 +52,12 @@ class ArticleSerializer < ActiveModel::Serializer
 
   private
   def previous_article
-    Article.where('created_at < ?', object.created_at).order('created_at desc').first
+    Article.where(published: true).where('created_at < ?', object.created_at)
+           .order('created_at desc').first
   end
 
   def next_article
-    Article.where('created_at > ?', object.created_at).order(:created_at).first
+    Article.where(published: true).where('created_at > ?', object.created_at)
+           .order(:created_at).first
   end
 end


### PR DESCRIPTION
## 必要な理由
* 

## 対応内容
### フロントエンドの変更
* 

### サーバサイドの変更
* 公開済みの記事のみ次の記事、前の記事に表示するようクエリを修正
* 公開状況変更時に次の記事、前の記事が取得できなかったので取得するように変更

## その他（確認したいことがあれば）
* 

