### PR TITLE
titleタグに記事のタイトルを含める

### DIFF
--- a/client/src/app/components/article/article.component.ts
+++ b/client/src/app/components/article/article.component.ts
@@ -4,7 +4,8 @@ import { Article } from '../../shared/models/article';
 import { ActivatedRoute } from '@angular/router';
 import { AuthService } from '../../shared/services/auth.service';
 import { ConfirmDialogService } from '../../shared/services//confirm-dialog.service';
-import { Meta } from '@angular/platform-browser';
+import { Meta, Title } from '@angular/platform-browser';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-article',
@@ -16,6 +17,7 @@ export class ArticleComponent implements OnInit {
   articleLoaded: boolean;
   loginState: boolean;
   articleId: number;
+  blogTitle = environment.title;
 
   constructor(
     private articleService: ArticleService,
@@ -23,6 +25,7 @@ export class ArticleComponent implements OnInit {
     private authService: AuthService,
     private confirmDialogService: ConfirmDialogService,
     private metaService: Meta,
+    private titleService: Title,
   ) {}
 
   ngOnInit() {
@@ -43,6 +46,7 @@ export class ArticleComponent implements OnInit {
     this.articleService.getArticles({ limit: 1 }).subscribe((response) => {
       if (response.length > 0) {
         this.article = response[0];
+        this.titleService.setTitle(`${this.article.title} | ${this.blogTitle}`);
         this.setMetaTag();
         this.articleLoaded = true;
       }
@@ -52,6 +56,7 @@ export class ArticleComponent implements OnInit {
   getArticle(articleId: number) {
     this.articleService.getArticle(articleId).subscribe((response) => {
       this.article = response;
+      this.titleService.setTitle(`${this.article.title} | ${this.blogTitle}`);
       this.setMetaTag();
       this.articleLoaded = true;
     });

--- a/client/src/app/components/header/header.component.html
+++ b/client/src/app/components/header/header.component.html
@@ -1,7 +1,7 @@
 <div class='header-block'>
   <div class='title-block'>
-    <h1 *ngIf="blogInformationLoaded">
-      <span class='click-util' [routerLink]="['/']">{{blogInformation.title}}</span>
+    <h1>
+      <span class='click-util' [routerLink]="['/']">{{title}}</span>
     </h1>
   </div>
 </div>

--- a/client/src/app/components/header/header.component.ts
+++ b/client/src/app/components/header/header.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { BlogInformation } from '../../shared/models/blog-information';
-import { BlogInformationService } from '../../shared/services/blog-information.service';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-header',
@@ -8,23 +7,9 @@ import { BlogInformationService } from '../../shared/services/blog-information.s
   styleUrls: ['./header.component.scss'],
 })
 export class HeaderComponent implements OnInit {
-  blogInformation: BlogInformation;
-  blogInformationLoaded: boolean;
+  title = environment.title;
 
-  constructor(private blogInformationService: BlogInformationService) {}
+  constructor() {}
 
-  ngOnInit() {
-    this.blogInformationLoaded = false;
-    this.getBlogInformation();
-  }
-
-  getBlogInformation() {
-    this.blogInformationService.getBlogInformation().subscribe(
-      (response) => {
-        this.blogInformation = response;
-        this.blogInformationLoaded = true;
-      },
-      (error) => {},
-    );
-  }
+  ngOnInit() {}
 }

--- a/client/src/environments/environment.prod.ts
+++ b/client/src/environments/environment.prod.ts
@@ -2,4 +2,5 @@ export const environment = {
   production: true,
   apiEndpoint: 'https://kuzugr.com/api/v1',
   uploadFileEndpoint: 'https://kuzugr.com/api/v1/upload_files',
+  title: 'ロックとギターとプログラミング',
 };

--- a/client/src/environments/environment.ts
+++ b/client/src/environments/environment.ts
@@ -6,6 +6,7 @@ export const environment = {
   production: false,
   apiEndpoint: 'http://local.kuzugr.com:3000/api/v1',
   uploadFileEndpoint: 'http://local.kuzugr.com:3000/api/v1/upload_files',
+  title: 'ロックとギターとプログラミング',
 };
 
 /*


### PR DESCRIPTION
## 必要な理由
* 検索エンジンでのみやすさを考慮

## 対応内容
### フロントエンドの変更
* 記事情報取得後にtitleタグに記事のタイトルを追加
* ブログタイトルを定数で持つように変更したので、header部で使用するタイトルも定数から取得するように変更

### サーバサイドの変更
* 

## その他（確認したいことがあれば）
* 

