### PR TITLE
titleタグを記事タイトルのみに変更

### DIFF
--- a/client/src/app/components/article/article.component.ts
+++ b/client/src/app/components/article/article.component.ts
@@ -46,7 +46,7 @@ export class ArticleComponent implements OnInit {
     this.articleService.getArticles({ limit: 1 }).subscribe((response) => {
       if (response.length > 0) {
         this.article = response[0];
-        this.titleService.setTitle(`${this.article.title} | ${this.blogTitle}`);
+        this.titleService.setTitle(this.article.title);
         this.setMetaTag();
         this.articleLoaded = true;
       }
@@ -56,7 +56,7 @@ export class ArticleComponent implements OnInit {
   getArticle(articleId: number) {
     this.articleService.getArticle(articleId).subscribe((response) => {
       this.article = response;
-      this.titleService.setTitle(`${this.article.title} | ${this.blogTitle}`);
+      this.titleService.setTitle(this.article.title);
       this.setMetaTag();
       this.articleLoaded = true;
     });

--- a/client/src/app/components/article/create-article/create-article.component.ts
+++ b/client/src/app/components/article/create-article/create-article.component.ts
@@ -29,7 +29,7 @@ export class CreateArticleComponent implements OnInit {
   validationMessages = {
     title: {
       required: 'タイトルを入力してください。',
-      maxlength: 'タイトルは100文字以内で入力してください。',
+      maxlength: 'タイトルは40文字以内で入力してください。',
     },
     mark_content: {
       required: '本文を入力してください。',
@@ -114,7 +114,7 @@ export class CreateArticleComponent implements OnInit {
       this.getArticle(this.articleId);
     } else {
       this.form = new FormGroup({
-        title: new FormControl('', [Validators.required, Validators.maxLength(100)]),
+        title: new FormControl('', [Validators.required, Validators.maxLength(40)]),
         mark_content: new FormControl('', [Validators.required]),
         category_id: new FormControl('', [Validators.required]),
       });
@@ -126,7 +126,7 @@ export class CreateArticleComponent implements OnInit {
     this.articleService.getArticle(articleId).subscribe(
       (response) => {
         this.form = new FormGroup({
-          title: new FormControl(response.title, [Validators.required, Validators.maxLength(100)]),
+          title: new FormControl(response.title, [Validators.required, Validators.maxLength(40)]),
           mark_content: new FormControl(response.mark_content, [Validators.required]),
           category_id: new FormControl(response.category_id, [Validators.required]),
         });


### PR DESCRIPTION
## 必要な理由
* 検索時のみやすさを考慮したため

## 対応内容
### フロントエンドの変更
* titleタグを記事タイトルのみに変更
* フロント側の記事タイトルのバリデーションを40文字に変更

### サーバサイドの変更
* 

## その他（確認したいことがあれば）
* 

