### PR TITLE
記事編集画面でブラウザバックなどを行うとアラートを出すようにする

### DIFF
--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -21,7 +21,7 @@ const routes: Routes = [
   {
     path: 'article',
     children: [
-      { path: 'create', component: CreateArticleComponent, canDeactivate: [BeforeunloadGuard]  },
+      { path: 'create', component: CreateArticleComponent, canDeactivate: [BeforeunloadGuard] },
       { path: ':article_id', component: ArticleComponent },
       { path: ':article_id/edit', component: CreateArticleComponent },
       { path: '**', component: TopComponent },

--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -10,6 +10,7 @@ import { ContactComponent } from './components/contact/contact.component';
 import { PrivacyPolicyComponent } from './components/privacy-policy/privacy-policy.component';
 import { TopComponent } from './components/top/top.component';
 import { SearchResultComponent } from './components/search-result/search-result.component';
+import { BeforeunloadGuard } from './shared/guards/beforeunload.guard';
 
 const routes: Routes = [
   { path: '', component: TopComponent },
@@ -20,7 +21,7 @@ const routes: Routes = [
   {
     path: 'article',
     children: [
-      { path: 'create', component: CreateArticleComponent },
+      { path: 'create', component: CreateArticleComponent, canDeactivate: [BeforeunloadGuard]  },
       { path: ':article_id', component: ArticleComponent },
       { path: ':article_id/edit', component: CreateArticleComponent },
       { path: '**', component: TopComponent },
@@ -33,6 +34,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
+  providers: [BeforeunloadGuard],
   imports: [
     RouterModule.forRoot(routes, {
       scrollPositionRestoration: 'enabled',

--- a/client/src/app/components/article/create-article/create-article.component.ts
+++ b/client/src/app/components/article/create-article/create-article.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, HostListener } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { ValidateForm } from '../../../shared/functions/validate-forms';
 import { ArticleService } from '../../../shared/services//article.service';
@@ -9,13 +9,14 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { MarkdownService } from 'ngx-markdown';
 import { environment } from '../../../../environments/environment';
 import { AuthService } from '../../../shared/services/auth.service';
+import { OnBeforeunload } from 'app/shared/guards/beforeunload.guard';
 
 @Component({
   selector: 'app-create-article',
   templateUrl: './create-article.component.html',
   styleUrls: ['./create-article.component.scss'],
 })
-export class CreateArticleComponent implements OnInit {
+export class CreateArticleComponent implements OnInit, OnBeforeunload {
   form: FormGroup;
   article: Article;
   articleLoaded: boolean;
@@ -41,6 +42,7 @@ export class CreateArticleComponent implements OnInit {
       required: 'カテゴリを選択してください。',
     },
   };
+  submitted = false;
 
   constructor(
     private articleService: ArticleService,
@@ -93,6 +95,7 @@ export class CreateArticleComponent implements OnInit {
   createArticle() {
     this.articleService.createArticle(this.article).subscribe(
       (response) => {
+        this.submitted = true
         this.router.navigateByUrl(`/article/${response.id}`);
       },
       (error) => {
@@ -104,6 +107,7 @@ export class CreateArticleComponent implements OnInit {
   editArticle() {
     this.articleService.editArticle(this.article, this.articleId).subscribe(
       (response) => {
+        this.submitted = true
         this.router.navigateByUrl(`/article/${this.articleId}`);
       },
       (error) => {
@@ -159,6 +163,17 @@ export class CreateArticleComponent implements OnInit {
       },
       (error) => {},
     );
+  }
+
+  shouldConfirmOnBeforeunload() {
+    return !this.submitted;
+  }
+
+  @HostListener('window:beforeunload', ['$event'])
+  beforeUnload(e: Event) {
+    if (this.shouldConfirmOnBeforeunload()) {
+      e.returnValue = true;
+    }
   }
   // tslint:disable-next-line:max-file-line-count
 }

--- a/client/src/app/components/article/create-article/create-article.component.ts
+++ b/client/src/app/components/article/create-article/create-article.component.ts
@@ -95,7 +95,7 @@ export class CreateArticleComponent implements OnInit, OnBeforeunload {
   createArticle() {
     this.articleService.createArticle(this.article).subscribe(
       (response) => {
-        this.submitted = true
+        this.submitted = true;
         this.router.navigateByUrl(`/article/${response.id}`);
       },
       (error) => {
@@ -107,7 +107,7 @@ export class CreateArticleComponent implements OnInit, OnBeforeunload {
   editArticle() {
     this.articleService.editArticle(this.article, this.articleId).subscribe(
       (response) => {
-        this.submitted = true
+        this.submitted = true;
         this.router.navigateByUrl(`/article/${this.articleId}`);
       },
       (error) => {

--- a/client/src/app/shared/guards/beforeunload.guard.ts
+++ b/client/src/app/shared/guards/beforeunload.guard.ts
@@ -1,0 +1,18 @@
+import { Injectable } from "@angular/core";
+import { CanDeactivate } from "@angular/router";
+
+export interface OnBeforeunload {
+  shouldConfirmOnBeforeunload: () => boolean;
+}
+
+@Injectable()
+export class BeforeunloadGuard implements CanDeactivate<OnBeforeunload> {
+  canDeactivate(component: OnBeforeunload) {
+    if (component.shouldConfirmOnBeforeunload()) {
+      const msg = 'このページを離れてもよろしいですか？\
+        \n行った変更が保存されない可能性があります。';
+      return confirm(msg);
+    }
+    return true;
+  }
+}

--- a/client/src/app/shared/guards/beforeunload.guard.ts
+++ b/client/src/app/shared/guards/beforeunload.guard.ts
@@ -1,5 +1,5 @@
-import { Injectable } from "@angular/core";
-import { CanDeactivate } from "@angular/router";
+import { Injectable } from '@angular/core';
+import { CanDeactivate } from '@angular/router';
 
 export interface OnBeforeunload {
   shouldConfirmOnBeforeunload: () => boolean;


### PR DESCRIPTION
## 必要な理由
* 記事作成中に誤ってブラウザバックなどをしてしまうことがあるため

## 対応内容
### フロントエンドの変更
* 

### サーバサイドの変更
* ブラウザバック、リロード時にアラートを出すguardを作成

## その他（確認したいことがあれば）
* 

